### PR TITLE
Fix issue: 10099 - create table failed when using viewfs

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -528,7 +528,7 @@ public final class HiveWriteUtils
         }
 
         // create a temporary directory on the same filesystem
-        Path temporaryRoot = new Path(targetPath, temporaryPrefix);
+        Path temporaryRoot = new Path(targetPath.getParent(), temporaryPrefix);
         Path temporaryPath = new Path(temporaryRoot, randomUUID().toString());
 
         createDirectory(context, hdfsEnvironment, temporaryPath);


### PR DESCRIPTION
Details of the bug here: https://github.com/prestodb/presto/issues/10099
Tested out create and CTAS successfully.
Create:
```
presto:pnarang> CREATE TABLE piyush_orders_test_7( orderkey bigint, orderstatus varchar, totalprice double, orderdate date ) WITH (format = 'ORC');
CREATE TABLE
```

CTAS:
```
presto:pnarang> create table my_bi_dim_campaign as select * from bossdb.bi_dim_campaign limit 1;
CREATE TABLE: 1 row

Query 20180409_195628_00001_gkhjv, FINISHED, 1 node
http://localhost:8080/query.html?20180409_195628_00001_gkhjv
Splits: 52 total, 52 done (100.00%)
CPU Time: 1.8s total,   119 rows/s, 13.1KB/s, 6% active
Per Node: 0.0 parallelism,     3 rows/s,   342B/s
Parallelism: 0.0
1:12 [220 rows, 24.1KB] [3 rows/s, 342B/s]
```

There's an open PR in OSS Presto - https://github.com/prestodb/presto/pull/10102
If that gets merged / resolved we're good, else we could use this as a temporary stopgap. 