### PR TITLE
Make presto server Kerberos service hostname component configurable.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosAuthenticator.java
@@ -64,7 +64,8 @@ public class KerberosAuthenticator
         System.setProperty("java.security.krb5.conf", config.getKerberosConfig().getAbsolutePath());
 
         try {
-            String hostname = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
+            String canonicalLocalHostName = InetAddress.getLocalHost().getCanonicalHostName().toLowerCase(Locale.US);
+            String hostname = config.getServiceHostName() == null ? canonicalLocalHostName : config.getServiceHostName();
             String servicePrincipal = config.getServiceName() + "/" + hostname;
             loginContext = new LoginContext("", null, null, new Configuration()
             {

--- a/presto-main/src/main/java/com/facebook/presto/server/security/KerberosConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/security/KerberosConfig.java
@@ -21,8 +21,11 @@ import java.io.File;
 
 public class KerberosConfig
 {
+    public static final String HTTP_SERVER_AUTHENTICATION_KRB5_KEYTAB = "http.server.authentication.krb5.keytab";
+
     private File kerberosConfig;
     private String serviceName;
+    private String serviceHostName;
     private File keytab;
 
     @NotNull
@@ -35,6 +38,18 @@ public class KerberosConfig
     public KerberosConfig setKerberosConfig(File kerberosConfig)
     {
         this.kerberosConfig = kerberosConfig;
+        return this;
+    }
+
+    public String getServiceHostName()
+    {
+        return serviceHostName;
+    }
+
+    @Config("http.server.authentication.krb5.service-hostname")
+    public KerberosConfig setServiceHostName(String serviceHostName)
+    {
+        this.serviceHostName = serviceHostName;
         return this;
     }
 
@@ -56,7 +71,7 @@ public class KerberosConfig
         return keytab;
     }
 
-    @Config("http.server.authentication.krb5.keytab")
+    @Config(HTTP_SERVER_AUTHENTICATION_KRB5_KEYTAB)
     public KerberosConfig setKeytab(File keytab)
     {
         this.keytab = keytab;

--- a/presto-main/src/test/java/com/facebook/presto/server/security/TestKerberosConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/security/TestKerberosConfig.java
@@ -28,6 +28,7 @@ public class TestKerberosConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(KerberosConfig.class)
                 .setKerberosConfig(null)
                 .setServiceName(null)
+                .setServiceHostName(null)
                 .setKeytab(null));
     }
 
@@ -37,12 +38,14 @@ public class TestKerberosConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http.authentication.krb5.config", "/etc/krb5.conf")
                 .put("http.server.authentication.krb5.service-name", "airlift")
+                .put("http.server.authentication.krb5.service-hostname", "presto.example.com")
                 .put("http.server.authentication.krb5.keytab", "/tmp/presto.keytab")
                 .build();
 
         KerberosConfig expected = new KerberosConfig()
                 .setKerberosConfig(new File("/etc/krb5.conf"))
                 .setServiceName("airlift")
+                .setServiceHostName("presto.example.com")
                 .setKeytab(new File("/tmp/presto.keytab"));
 
         ConfigAssertions.assertFullMapping(properties, expected);


### PR DESCRIPTION
Needed to make client-coordinator Kerberos authentication works with a trusted proxy in the middle.