### PR TITLE
Use service instead of node address in consul node response

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/DiscoveryHiveCluster.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/DiscoveryHiveCluster.java
@@ -147,10 +147,10 @@ public class DiscoveryHiveCluster
         }
         List<ServiceHealth> response = result.getResponse();
         return response.stream().map(uri -> {
-            String host = uri.getNode().getNode();
-            if (host == null || host.isEmpty()) {
-                host = uri.getNode().getAddress();
-            }
+        	String host = uri.getService().getAddress();
+        	if (host == null || host.isEmpty()) {
+        	  host = uri.getNode().getAddress();
+        	}
             int port = uri.getService().getPort();
             return HostAndPort.fromParts(host, port);
         }).collect(toList());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/DiscoveryHiveCluster.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/metastore/thrift/DiscoveryHiveCluster.java
@@ -148,6 +148,9 @@ public class DiscoveryHiveCluster
         List<ServiceHealth> response = result.getResponse();
         return response.stream().map(uri -> {
             String host = uri.getNode().getNode();
+            if (host == null || host.isEmpty()) {
+                host = uri.getNode().getAddress();
+            }
             int port = uri.getService().getPort();
             return HostAndPort.fromParts(host, port);
         }).collect(toList());


### PR DESCRIPTION
Update DiscoveryHiveCluster to cope with the latest mesos network isolation changes  (https://confluence.criteois.com/display/MESOS/Network+isolation+on+Mesos)